### PR TITLE
fix sample schema validation type

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ POST:
           type: string
         age:
           title: age
-          type: int
+          type: integer
       additionalProperties: true
       required: []
 
@@ -73,7 +73,7 @@ POST:
           type: string
         age:
           title: age
-          type: int
+          type: integer
       additionalProperties: true
       required: [language, age]
 ```
@@ -97,7 +97,7 @@ API endpoint: https://<i></i>example.com/v2/account/update_profile
           },
           "age": {
             "title": "age",
-            "type": "int"
+            "type": "integer"
           }
         },
         "additionalProperties": true,
@@ -116,7 +116,7 @@ API endpoint: https://<i></i>example.com/v2/account/update_profile
           },
           "age": {
             "title": "age",
-            "type": "int"
+            "type": "integer"
           }
         },
         "additionalProperties": true,

--- a/sample/collection/account/settings.yml
+++ b/sample/collection/account/settings.yml
@@ -11,7 +11,7 @@ POST:
           type: string
         age:
           title: age
-          type: int
+          type: integer
       additionalProperties: true
       required: []
 
@@ -26,6 +26,6 @@ POST:
           type: string
         age:
           title: age
-          type: int
+          type: integer
       additionalProperties: true
       required: [language, age]

--- a/sample/collection/account/update_profile.json
+++ b/sample/collection/account/update_profile.json
@@ -14,7 +14,7 @@
           },
           "age": {
             "title": "age",
-            "type": "int"
+            "type": "integer"
           }
         },
         "additionalProperties": true,
@@ -33,7 +33,7 @@
           },
           "age": {
             "title": "age",
-            "type": "int"
+            "type": "integer"
           }
         },
         "additionalProperties": true,


### PR DESCRIPTION
サンプル内で指定されている JSON Schema Draft 4 における整数型は `int` ではなく `integer` です。  
<http://json-schema.org/draft-04/schema#definitions>

`AbstractBodyStructure::setDefault()` はこれに準拠してますが、サンプルファイルのtype指定がinvalidなため、実際に生成すると `age` プロパティのダミー値が空配列 `[]` になってしまいます。

![](https://user-images.githubusercontent.com/4990822/29997500-a62ecf2e-904f-11e7-9d9e-067123f5bc3d.png)
